### PR TITLE
Increase tipBufferSize from 16 to 128

### DIFF
--- a/core/state_manager.go
+++ b/core/state_manager.go
@@ -38,7 +38,7 @@ import (
 
 const (
 	commitInterval = 4096
-	tipBufferSize  = 16
+	tipBufferSize  = 128
 )
 
 type TrieWriter interface {


### PR DESCRIPTION
This small change has a *huge* impact on web3 dApp usability. Almost all issues encountered with MetaMask and Songbird RPC endpoints will go away.
The issue is detailed here: https://github.com/MetaMask/metamask-extension/issues/13322
This patch makes the node to keep the last 128 state tries, instead of 16. Since MetaMask has a 20-seconds block number cache, keeping 16 state tries is not enough, because the number of produced blocks by the Flare Network in 20s can be much higher and MetaMask ends up asking for data in already pruned state tries.