### PR TITLE
Take into account votepower cap

### DIFF
--- a/plugin/evm/ftso_methods.go
+++ b/plugin/evm/ftso_methods.go
@@ -12,6 +12,8 @@ const (
 	WhitelistAddress  = "getVoterWhitelister"
 	WNATAddress       = "wNat"
 	VotepowerAddress  = "readVotePowerContract"
+	TotalSupply       = "totalSupply"
+	Settings          = "settings"
 	CurrentEpoch      = "getCurrentRewardEpoch"
 	RewardEpoch       = "rewardEpochs"
 	DataProviders     = "getFtsoWhitelistedPriceProviders"

--- a/plugin/evm/ftso_snapshot.go
+++ b/plugin/evm/ftso_snapshot.go
@@ -39,7 +39,7 @@ func (f *FTSOSnapshot) Cap() (float64, error) {
 		AtBlock(f.start).
 		OnContract(f.contracts.Manager).
 		Execute(Settings).
-		Decode(&fraction, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		Decode(&fraction, nil, nil, nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		return 0, fmt.Errorf("could not get votepower threshold fraction: %w", err)
 	}

--- a/plugin/evm/ftso_system.go
+++ b/plugin/evm/ftso_system.go
@@ -37,6 +37,7 @@ type FTSOContracts struct {
 	Manager    EVMContract
 	Rewards    EVMContract
 	Whitelist  EVMContract
+	WNAT       EVMContract
 	Votepower  EVMContract
 	Validation EVMContract
 }
@@ -207,6 +208,7 @@ func (f *FTSOSystem) Contracts(hash common.Hash) (FTSOContracts, error) {
 		Manager:    manager,
 		Rewards:    rewards,
 		Whitelist:  whitelist,
+		WNAT:       wnat,
 		Votepower:  votepower,
 		Validation: f.validation,
 	}


### PR DESCRIPTION
This PR makes sure that we cap the votepower for FTSO providers at the configured cap. Otherwise, capped FTSO validators would receive less validation weight than uncapped ones, even if their performance could be better.