### PR TITLE
Add default validators component

### DIFF
--- a/consensus/errors.go
+++ b/consensus/errors.go
@@ -26,7 +26,9 @@
 
 package consensus
 
-import "errors"
+import (
+	"errors"
+)
 
 var (
 	// ErrUnknownAncestor is returned when validating a block requires an ancestor

--- a/plugin/evm/service.go
+++ b/plugin/evm/service.go
@@ -513,8 +513,8 @@ type FlareAPI struct {
 	vm *VM
 }
 
-func (api *FlareAPI) DefaultValidators(_ context.Context) (map[string]uint64, error) {
-	validators, err := api.vm.validators.DefaultValidators()
+func (api *FlareAPI) DefaultValidators(_ context.Context, epoch uint64) (map[string]uint64, error) {
+	validators, err := api.vm.validators.DefaultValidators(epoch)
 	if err != nil {
 		return nil, fmt.Errorf("could not get default validators: %w", err)
 	}

--- a/plugin/evm/validators_cache.go
+++ b/plugin/evm/validators_cache.go
@@ -30,13 +30,13 @@ func WithCacheSize(slots uint) CacheOption {
 // ValidatorsCache wraps around a validator retriever and caches the results in
 // order to improve retrieval performance.
 type ValidatorsCache struct {
-	validators ValidatorRetriever
+	validators ValidatorsRetriever
 	cache      *lru.Cache
 }
 
 // NewValidatorCache creates a new LRU cache for validator retrieval with the
 // configured cache size.
-func NewValidatorsCache(validators ValidatorRetriever, opts ...CacheOption) *ValidatorsCache {
+func NewValidatorsCache(validators ValidatorsRetriever, opts ...CacheOption) *ValidatorsCache {
 
 	cfg := DefaultCacheConfig
 	for _, opt := range opts {

--- a/plugin/evm/validators_default.go
+++ b/plugin/evm/validators_default.go
@@ -81,9 +81,9 @@ func NewValidatorsDefault(chainID *big.Int) (*ValidatorsDefault, error) {
 		nodeIDs = songbirdNodeIDs
 		weight = songbirdValidatorWeight
 		steps = []Step{
-			{Epoch: 41, Cutoff: 15}, // go down to 15 default validators one week after main net
-			{Epoch: 43, Cutoff: 10}, // go down to 10 default validators three weeks after main net
-			{Epoch: 45, Cutoff: 5},  // go down to 5 default validators five weeks after main net
+			{Epoch: 42, Cutoff: 15}, // go down to 15 default validators two weeks after main net launch
+			{Epoch: 44, Cutoff: 10}, // go down to 10 default validators four weeks after main net launch
+			{Epoch: 46, Cutoff: 5},  // go down to 5 default validators six weeks after main net launch
 		}
 	case chainID.Cmp(params.FlareChainID) == 0:
 		nodeIDs = flareNodeIDs

--- a/plugin/evm/validators_default_test.go
+++ b/plugin/evm/validators_default_test.go
@@ -11,7 +11,10 @@ import (
 	"github.com/flare-foundation/coreth/params"
 )
 
-func TestGetDefaultValidators(t *testing.T) {
+func TestNewValidatorsDefault(t *testing.T) {
+}
+
+func TestValidatorsDefault_ByEpoch(t *testing.T) {
 	tests := []struct {
 		name    string
 		chainID *big.Int

--- a/plugin/evm/validators_normalizer.go
+++ b/plugin/evm/validators_normalizer.go
@@ -16,12 +16,12 @@ import (
 // how many validators are in a set.
 type ValidatorsNormalizer struct {
 	log        logging.Logger
-	validators ValidatorRetriever
+	validators ValidatorsRetriever
 }
 
 // NewValidatorsNormalizer wraps a new validators retriever in the normalizer, making
 // sure that all sets retrieved from the wrapper retriever have the same total weight.
-func NewValidatorsNormalizer(log logging.Logger, validators ValidatorRetriever) *ValidatorsNormalizer {
+func NewValidatorsNormalizer(log logging.Logger, validators ValidatorsRetriever) *ValidatorsNormalizer {
 
 	v := ValidatorsNormalizer{
 		log:        log,

--- a/plugin/evm/validators_transitioner.go
+++ b/plugin/evm/validators_transitioner.go
@@ -8,33 +8,23 @@ import (
 	"fmt"
 	"sort"
 
-	lru "github.com/hashicorp/golang-lru"
-
 	"github.com/flare-foundation/flare/ids"
 )
 
 // ValidatorsTransitioner transitions validators from a static set of validators
 // to a growing set of dynamic validators over a number of smooth steps.
 type ValidatorsTransitioner struct {
-	validators map[ids.ShortID]uint64
-	providers  ValidatorRetriever
-	cache      *lru.Cache
+	validators ValidatorsRetriever
+	providers  ValidatorsRetriever
 }
 
 // NewValidatorsTransitioner creates a transition from the given default validators
 // to the validators retrieved from the given FTSO validators retriever.
-func NewValidatorsTransitioner(validators map[ids.ShortID]uint64, providers ValidatorRetriever, options ...CacheOption) *ValidatorsTransitioner {
+func NewValidatorsTransitioner(validators ValidatorsRetriever, providers ValidatorsRetriever) *ValidatorsTransitioner {
 
-	cfg := DefaultCacheConfig
-	for _, opt := range options {
-		opt(&cfg)
-	}
-
-	cache, _ := lru.New(int(cfg.CacheSize))
 	v := ValidatorsTransitioner{
 		validators: validators,
 		providers:  providers,
-		cache:      cache,
 	}
 
 	return &v
@@ -47,92 +37,99 @@ func NewValidatorsTransitioner(validators map[ids.ShortID]uint64, providers Vali
 // validators have been entirely phased out.
 func (v *ValidatorsTransitioner) ByEpoch(epoch uint64) (map[ids.ShortID]uint64, error) {
 
-	// We need to get the FTSO providers for the previous epoch, so we need to
-	// check we are not at epoch zero.
-	if epoch == 0 {
-		return v.validators, nil
+	// Get the default validators for the requested epoch.
+	validators, err := v.validators.ByEpoch(epoch)
+	if err != nil {
+		return nil, fmt.Errorf("could not get default validators: %w", err)
 	}
 
-	// We start by getting the FTSO validators from the previous epoch. Since that
-	// epoch is over, votepower and rewards are available and we can compute the
-	// weights for them.
+	// We need to get the FTSO providers for the previous epoch, so we need to
+	// check we are not at epoch zero. For reward epoch zero, we always return
+	// the default validators.
+	if epoch == 0 {
+		return validators, nil
+	}
+
+	// Now that we know we are not at epoch zero, we can get the FTSO validators
+	// from the previous epoch. We have to use the previous epoch's FTSO validators
+	// because we need access to the full distributed rewards for the epoch, and
+	// they have not yet been determined for the currently active epoch.
 	providers, err := v.providers.ByEpoch(epoch - 1)
 	if err != nil {
 		return nil, fmt.Errorf("could not retrieve FTSO validators for previous epoch: %w", err)
 	}
 
-	// If there are none, we return the default validator set. This is an important
-	// point, as this is where we leave the recursion, where we decide how many
-	// default validators to keep.
+	// If there are no FTSO validators for the previous epoch, we return the default
+	// validators, as none of them can currently be phased out.
 	if len(providers) == 0 {
-		return v.validators, nil
+		return validators, nil
 	}
 
-	// At this point, we should start including some FTSO validators in the active
-	// validator set. This depends on how many we included in the previous set, so
-	// we recurse. The cache is there to avoid recursing all the way back to the
-	// first transition on later requests.
-	var previous map[ids.ShortID]uint64
-	entry, ok := v.cache.Get(epoch - 1)
-	if ok {
-		previous = entry.(map[ids.ShortID]uint64)
-	} else {
-		previous, err = v.ByEpoch(epoch - 1)
-		if err != nil {
-			return nil, fmt.Errorf("could not retrieve active validators for previous epoch: %w", err)
-		}
-		v.cache.Add(epoch-1, previous)
+	// At this point, we have some FTSO validators available, and we have some default
+	// validators available. In order to determine how many default validators to
+	// phase out, we first retrieve the active validators from the previous epoch.
+	previous, err := v.ByEpoch(epoch - 1)
+	if err != nil {
+		return nil, fmt.Errorf("could not retrieve active validators for previous epoch: %w", err)
 	}
 
-	// We compute the number of default validators included in the active validators
-	// from the last epoch.
-	include := 0
+	// We can then count the number of default validators that were included in the
+	// active validators from the previous epoch.
+	included := 0
 	for validator := range previous {
-		_, ok := v.validators[validator]
+		_, ok := validators[validator]
 		if ok {
-			include++
+			included++
 		}
 	}
 
-	// If there were no default validators in the previous active validators, we
-	// have completed the transition to FTSO validators.
-	if include == 0 {
+	// If there were no default validators included in the previous epoch at all,
+	// we have already completed the transition from default validators to FTSO
+	// validators, and we simply return the FTSO validators as active validators.
+	if included == 0 {
 		return providers, nil
 	}
 
-	// If the number of available FTSO validators is big enough to replace an
-	// additional default validator, we include one default validator less.
-	if len(providers) > len(v.validators)-include {
-		include--
+	// If the number of FTSO validators is enough to replace one additional default
+	// validator from the active set, we reduce the count of included default
+	// validators by one.
+	if len(providers) > len(validators)-included {
+		included--
 	}
 
-	// In order to always select the same default validators, we sort their IDs
-	// deterministically, and then cut off at the number we should still include.
-	validators := make([]ids.ShortID, 0, len(v.validators))
-	for validator := range v.validators {
-		validators = append(validators, validator)
+	// We then select the given number of included default validators. In order to
+	// make the selection deterministic, we sort the validator IDs for all default
+	// validators and then cut it off at the number of included ones.
+	validatorIDs := make([]ids.ShortID, 0, len(validators))
+	for validatorID := range validators {
+		validatorIDs = append(validatorIDs, validatorID)
 	}
-	sort.Slice(validators, func(i int, j int) bool {
-		return bytes.Compare(validators[i][:], validators[j][:]) < 0
+	sort.Slice(validatorIDs, func(i int, j int) bool {
+		return bytes.Compare(validatorIDs[i][:], validatorIDs[j][:]) < 0
 	})
-	validators = validators[:include]
+	validatorIDs = validatorIDs[:included]
 
-	// Next, we try to make sure that the default validators have proportionally
-	// the same average weighting as the FTSO validators.
+	// Once we fix FTSO validators and default validators, we can no longer use the
+	// default configured weight for default validators. Instead we use a proportional
+	// average. For example, if 3/10 default validators have been phased out, meaning
+	// 7/10 default validators are still in the set, then the default validators should
+	// have 70% of the total weight, and the FTSO validators should have 30% of the
+	// total weight.
 	providerWeight := uint64(0)
 	for _, weight := range providers {
 		providerWeight += weight
 	}
-	providerWeight /= uint64(len(v.validators) - include)
+	providerWeight /= uint64(len(validators) - included)
 
-	// Finally, we add the selected default validators to the set of the validators
-	// with the average weight we have calculated.
+	// We then add all available FTSO validators to the active validators first,
+	// followed by the remaining default validators with the calculated proportional
+	// average weight.
 	active := make(map[ids.ShortID]uint64, len(providers)+len(validators))
 	for provider, weight := range providers {
 		active[provider] = weight
 	}
-	for _, validator := range validators {
-		active[validator] = providerWeight
+	for _, validatorID := range validatorIDs {
+		active[validatorID] = providerWeight
 	}
 
 	return active, nil


### PR DESCRIPTION
This PR makes the default validators component a bit more flexible, so we can phase out some default validators after the FTSO validators take over.

Once the FTSO validators fully take over for the default validators, the default validators will only be used in two cases:

1. some FTSO validators unset their Node ID and thus stop running their validators; or
2. some catastrophic glitch on the FTSO makes reward payouts zero for one reward epoch.

In the first case, this change will ensure that default validators are only added back into the mix if the number falls much lower. So the network will keep running with 18, or even just 6, FTSO validators without falling back to centralized default validators.

In the second case, the network will fall back only on 3 or 5 default validators in case of a catastrophic glitch, which means we have to maintain less default validators running, reducing costs. Additionally, the transition away from default validators to FTSO  will happen much faster in that case.

The PR also makes it possible to phase out multiple default validators per reward epoch, and sets the values so that we reach an active validator set of mostly FTSO validators around Flare main network launch.